### PR TITLE
Added codecov.io coverage uploader to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
       - run: yarn
       - run: yarn test
 
+      - uses: codecov/codecov-action@v2
+
       - uses: daniellockyer/action-slack-build@master
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:

--- a/packages/custom-theme-settings-service/package.json
+++ b/packages/custom-theme-settings-service/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing c8 --check-coverage mocha './test/**/*.test.js'",
+    "test": "NODE_ENV=testing c8 --reporter text --reporter cobertura --check-coverage mocha './test/**/*.test.js'",
     "lint": "eslint . --ext .js --cache",
     "posttest": "yarn lint"
   },

--- a/packages/email-analytics-provider-mailgun/package.json
+++ b/packages/email-analytics-provider-mailgun/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing mocha './test/**/*.test.js'",
+    "test": "NODE_ENV=testing c8 --reporter text --reporter cobertura --check-coverage mocha './test/**/*.test.js'",
     "lint": "eslint . --ext .js --cache",
     "posttest": "yarn lint"
   },

--- a/packages/email-analytics-service/package.json
+++ b/packages/email-analytics-service/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing mocha './test/**/*.test.js'",
+    "test": "NODE_ENV=testing c8 --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "lint": "eslint . --ext .js --cache",
     "posttest": "yarn lint"
   },


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/CORE-74/improve-the-test-situation

- this commit adds the codecov GitHub Action into CI so we can upload
  coverage reports
- the coverage files need to be in XML for them to work with
  codecov, so this commit also adds cobertura (XML) as a reporter